### PR TITLE
Add claude-switch module + generic bin installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Convenience wrapper around ./install.sh
+# Override the bin dir:   make install BINDIR=/usr/local/bin
+# Install one tool:       make install TOOL=claude-switch
+BINDIR ?= $(HOME)/.local/bin
+TOOL   ?=
+
+.PHONY: install link uninstall list help
+
+help:
+	@./install.sh --help
+
+list:
+	@./install.sh --list --bindir "$(BINDIR)"
+
+install:
+	@./install.sh --bindir "$(BINDIR)" $(TOOL)
+
+link:
+	@./install.sh --link --bindir "$(BINDIR)" $(TOOL)
+
+uninstall:
+	@./install.sh --uninstall --bindir "$(BINDIR)" $(TOOL)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@
 | :--- | :--- |
 | **[K8s Bare Metal](scripts/k8s-bare-metal)** | Scripts to bootstrap HA Kubernetes clusters on bare-metal/VMs (Rancher, Calico, Longhorn). |
 | **[Cloudflare](scripts/cloudflare)** | Automations for Cloudflare Worker & Pages deployment and management. |
+| **[Claude Switch](scripts/claude-switch)** | Toggle the Claude Code CLI between Anthropic Cloud and Huawei MaaS (GLM) models. |
+
+---
+
+## 🛠 Installation
+
+Some modules ship runnable CLI tools (any `scripts/<module>/bin/`). Install them into your bin directory with the bundled installer:
+
+```bash
+git clone https://github.com/phimasonelabs/script-helper.git
+cd script-helper
+
+./install.sh --list                   # list installable tools
+./install.sh                          # install all tools into ~/.local/bin
+./install.sh claude-switch            # install a single tool
+./install.sh --bindir /usr/local/bin  # custom location
+./install.sh --uninstall claude-switch
+```
+
+`make install` / `make list` / `make uninstall` wrap the same script. Use `--link` (dev mode) to symlink tools to the repo so `git pull` updates them in place.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# install.sh — install script-helper CLI tools into your bin directory.
+#
+# A "tool" is any directory under scripts/ that contains a bin/ subdirectory.
+# Every executable in scripts/<tool>/bin/ is installed into the bin dir, and any
+# symlinks declared in scripts/<tool>/links.txt are (re)created alongside it.
+#
+# Usage:
+#   ./install.sh [options] [tool ...]
+#
+# Options:
+#   --bindir DIR   install into DIR     (default: $XDG_BIN_HOME or ~/.local/bin)
+#   --copy         copy tools into bindir   (default; survives repo move/delete)
+#   --link         symlink tools to this repo (dev mode; updates on git pull)
+#   --uninstall    remove the selected tools' files from bindir
+#   --list         list installable tools and exit
+#   -h, --help     show this help
+#
+# Examples:
+#   ./install.sh                          # install all tools into ~/.local/bin
+#   ./install.sh claude-switch            # install just one tool
+#   ./install.sh --link                   # dev mode (symlink into the repo)
+#   ./install.sh --bindir /usr/local/bin  # custom location
+#   ./install.sh --uninstall claude-switch
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$REPO_DIR/scripts"
+BINDIR="${BINDIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
+MODE="copy"
+ACTION="install"
+
+_tty() { [ -t 1 ]; }
+col()  { _tty && printf '\033[%sm' "$1" || true; }
+info() { col 36; printf '%s\n' "$*"; col 0; }
+ok()   { col 32; printf '%s\n' "$*"; col 0; }
+warn() { col 33; printf '%s\n' "$*"; col 0; }
+die()  { col 31; printf '%s\n' "$*" >&2; col 0; exit 1; }
+
+usage() {
+  cat <<'USAGE'
+install.sh — install script-helper CLI tools into your bin directory.
+
+Usage: ./install.sh [options] [tool ...]
+
+  --bindir DIR   install into DIR     (default: $XDG_BIN_HOME or ~/.local/bin)
+  --copy         copy into bindir     (default; survives repo move/delete)
+  --link         symlink to this repo (dev mode; updates on git pull)
+  --uninstall    remove the selected tools' files from bindir
+  --list         list installable tools and exit
+  -h, --help     show this help
+
+Examples:
+  ./install.sh                          install all tools into ~/.local/bin
+  ./install.sh claude-switch            install just one tool
+  ./install.sh --link                   dev mode (symlink into the repo)
+  ./install.sh --bindir /usr/local/bin  custom location
+  ./install.sh --uninstall claude-switch
+USAGE
+}
+
+TOOLS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bindir)   BINDIR="${2:?--bindir needs a directory}"; shift 2 ;;
+    --bindir=*) BINDIR="${1#*=}"; shift ;;
+    --copy)     MODE="copy"; shift ;;
+    --link|--symlink) MODE="link"; shift ;;
+    --uninstall|--remove) ACTION="uninstall"; shift ;;
+    --list|-l)  ACTION="list"; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    --) shift; while [ $# -gt 0 ]; do TOOLS+=("$1"); shift; done ;;
+    -*) die "unknown option: $1 (try --help)" ;;
+    *)  TOOLS+=("$1"); shift ;;
+  esac
+done
+
+# All installable tools = scripts/*/ dirs that contain a bin/ subdir.
+discover() {
+  local d
+  for d in "$SCRIPTS_DIR"/*/; do
+    [ -d "${d}bin" ] || continue
+    basename "$d"
+  done
+}
+
+# Selected = explicit args, else everything discovered.
+if [ "${#TOOLS[@]}" -gt 0 ]; then
+  SELECTED="$(printf '%s\n' "${TOOLS[@]}")"
+else
+  SELECTED="$(discover)"
+fi
+[ -n "$SELECTED" ] || die "No installable tools found under $SCRIPTS_DIR"
+
+# --- list ---------------------------------------------------------------------
+if [ "$ACTION" = "list" ]; then
+  info "Installable tools (bindir: $BINDIR):"
+  for t in $(discover); do
+    printf '  %s\n' "$t"
+    for e in "$SCRIPTS_DIR/$t/bin/"*; do
+      [ -f "$e" ] && printf '      bin : %s\n' "$(basename "$e")"
+    done
+    if [ -f "$SCRIPTS_DIR/$t/links.txt" ]; then
+      while read -r l tgt _; do
+        case "$l" in ''|\#*) continue ;; esac
+        printf '      link: %s -> %s\n' "$l" "$tgt"
+      done < "$SCRIPTS_DIR/$t/links.txt"
+    fi
+  done
+  exit 0
+fi
+
+# --- install / uninstall ------------------------------------------------------
+[ "$ACTION" = "install" ] && mkdir -p "$BINDIR"
+
+for t in $SELECTED; do
+  tdir="$SCRIPTS_DIR/$t"
+  [ -d "$tdir/bin" ] || die "no such tool: '$t' (try: ./install.sh --list)"
+
+  for e in "$tdir/bin/"*; do
+    [ -f "$e" ] || continue
+    name="$(basename "$e")"; dest="$BINDIR/$name"
+    if [ "$ACTION" = "uninstall" ]; then
+      rm -f "$dest" && info "removed  $dest"
+    elif [ "$MODE" = "link" ]; then
+      ln -sfn "$e" "$dest"; ok "linked   $name -> $dest"
+    else
+      cp "$e" "$dest"; chmod 755 "$dest"; ok "installed $name -> $dest"
+    fi
+  done
+
+  if [ -f "$tdir/links.txt" ]; then
+    while read -r l tgt _; do
+      case "$l" in ''|\#*) continue ;; esac
+      [ -n "${tgt:-}" ] || continue
+      if [ "$ACTION" = "uninstall" ]; then
+        rm -f "$BINDIR/$l" && info "removed  $BINDIR/$l"
+      else
+        ln -sfn "$tgt" "$BINDIR/$l"; ok "linked   $l -> $tgt"
+      fi
+    done < "$tdir/links.txt"
+  fi
+done
+
+if [ "$ACTION" = "install" ]; then
+  case ":$PATH:" in
+    *":$BINDIR:"*) ok "Done. '$BINDIR' is on your PATH." ;;
+    *) warn "Done — but '$BINDIR' is NOT on your PATH."
+       warn "  Add this to your ~/.zshrc (or ~/.bashrc):"
+       warn "    export PATH=\"$BINDIR:\$PATH\"" ;;
+  esac
+else
+  ok "Uninstall complete."
+fi

--- a/scripts/claude-switch/README.md
+++ b/scripts/claude-switch/README.md
@@ -1,0 +1,89 @@
+# claude-switch
+
+Toggle the **Claude Code** CLI between **Anthropic Cloud** and **Huawei MaaS (GLM)** — with one script and two friendly commands.
+
+Huawei ModelArts Studio (MaaS) exposes a native **Anthropic-compatible** endpoint, so no proxy or router is needed: `claude-huawei` just points Claude Code at MaaS with the right model, and `claude-cloud` runs your normal Anthropic session.
+
+## 🔧 Features
+
+- `claude-cloud` — Claude Code on Anthropic (your claude.ai login/subscription)
+- `claude-huawei` — Claude Code on Huawei MaaS GLM (default model `glm-5.2`)
+- Per-process env isolation — switching never leaks into your shell, and cloud mode force-clears overrides
+- Preflight reachability check that refuses to launch a broken session
+- One-place config in `~/.huawei-maas`; per-run overrides via `CLAUDE_HUAWEI_*` env vars
+- Secret stays in `~/.huawei-maas` (chmod 600) — never on a command line
+
+## 📦 Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and on your `PATH` (`claude --version`)
+- `curl` and `python3` (for the preflight/`models` helpers)
+- A Huawei Cloud **MaaS** API key
+
+## 🚀 Install
+
+From the repo root (installs `claude-switch` + the `claude-cloud` / `claude-huawei` symlinks into your bin dir):
+
+```bash
+./install.sh claude-switch
+# or:  make install TOOL=claude-switch
+# custom location:  ./install.sh claude-switch --bindir /usr/local/bin
+```
+
+Then set up your key file:
+
+```bash
+cp scripts/claude-switch/huawei-maas.example ~/.huawei-maas
+chmod 600 ~/.huawei-maas
+# edit ~/.huawei-maas and paste your MaaS API key on the first non-comment line
+```
+
+## 🧭 Usage
+
+| Command | Backend |
+| :--- | :--- |
+| `claude-cloud [claude args…]` | Anthropic Claude (your login/subscription) |
+| `claude-huawei [claude args…]` | Huawei MaaS GLM (default `glm-5.2`) |
+| `claude-switch cloud \| huawei [args…]` | Same as above (aliases: `glm`, `maas`) |
+| `claude-switch check` | Probe endpoint + model, **no** Claude launch |
+| `claude-switch models` | List models your key can see (catalog) |
+| `claude-switch help` | Usage |
+
+Any arguments after the command pass straight through to `claude` (`-p`, `-c`, `--resume`, …):
+
+```bash
+claude-huawei                                # interactive GLM session
+claude-cloud  --resume                       # back to Anthropic
+claude-huawei -p "refactor this function"    # headless one-shot
+claude-switch check                          # "✓ reachable" before relying on it
+```
+
+## 🎚 Choosing the model
+
+- **Persistent default** — a `model=` line in `~/.huawei-maas` (e.g. `model=glm-5.2`).
+- **One-off override** — `CLAUDE_HUAWEI_MODEL=glm-5.1 claude-huawei` (doesn't change the default).
+
+## ⚙️ Config & environment
+
+| Setting | Default | Override |
+| :--- | :--- | :--- |
+| Key file | `~/.huawei-maas` | `CLAUDE_HUAWEI_KEYFILE` |
+| Model | `glm-5.2` | `CLAUDE_HUAWEI_MODEL` |
+| Region | `ap-southeast-1` | `CLAUDE_HUAWEI_REGION` |
+| Base URL | `https://api-<region>.modelarts-maas.com/anthropic` | `CLAUDE_HUAWEI_BASE_URL` |
+| Preflight | on | `CLAUDE_HUAWEI_NO_CHECK=1` to skip |
+
+The key file accepts a bare key line plus optional `model=` / `region=` / `base_url=` lines.
+
+## 📝 Notes
+
+- A model can be **listed** (`claude-switch models`) yet not **callable** — Huawei MaaS gates inference per model. If a model returns **HTTP 403 `ModelArts.81004` "no access"**, subscribe/activate that model's real-time inference service in the MaaS console (region `ap-southeast-1`), then re-run `claude-switch check`.
+- In Huawei mode you'll see a benign notice that **claude.ai connectors are disabled** — expected, because the API token takes precedence over your claude.ai login while using a third-party endpoint.
+- Each command launches a **new** `claude` process; you switch backends by starting a fresh session.
+
+## ❌ Uninstall
+
+```bash
+./install.sh --uninstall claude-switch
+# or:  make uninstall TOOL=claude-switch
+```
+(Leaves your `~/.huawei-maas` untouched.)

--- a/scripts/claude-switch/bin/claude-switch
+++ b/scripts/claude-switch/bin/claude-switch
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# claude-switch — run Claude Code against either Anthropic Cloud or Huawei MaaS (GLM).
+#
+# Two friendly entrypoints (symlinks to this one script):
+#   claude-cloud   [claude args...]   normal Anthropic Claude (your login / subscription)
+#   claude-huawei  [claude args...]   Huawei MaaS GLM via its Anthropic-compatible endpoint
+#
+# Or call this script directly:
+#   claude-switch cloud   [claude args...]
+#   claude-switch huawei  [claude args...]
+#   claude-switch check        # probe the Huawei endpoint/model without launching Claude
+#   claude-switch models       # list the models your Huawei key can see
+#   claude-switch help
+#
+# ── Huawei config ────────────────────────────────────────────────────────────
+# Key file: ~/.huawei-maas   (override with $CLAUDE_HUAWEI_KEYFILE)
+#   Either a single line containing JUST your MaaS API key (current setup), OR
+#   key=, model=, base_url=, region= lines (any subset) for one-place config:
+#       key=UUIy55...
+#       model=glm-5.2
+#       region=ap-southeast-1
+#
+# Env overrides (win over the file, handy for one-off runs):
+#   CLAUDE_HUAWEI_MODEL      default: glm-5.2
+#   CLAUDE_HUAWEI_REGION     default: ap-southeast-1
+#   CLAUDE_HUAWEI_BASE_URL   default: https://api-<region>.modelarts-maas.com/anthropic
+#   CLAUDE_HUAWEI_NO_CHECK=1 skip the preflight reachability probe
+#
+set -euo pipefail
+
+PROG="$(basename "$0")"
+DEFAULT_REGION="ap-southeast-1"
+DEFAULT_MODEL="glm-5.2"
+KEYFILE="${CLAUDE_HUAWEI_KEYFILE:-$HOME/.huawei-maas}"
+
+# ── pretty logging (all to stderr so Claude's stdout stays clean) ─────────────
+_c() { [ -t 2 ] && printf '\033[%sm' "$1" >&2 || true; }
+err()  { _c 31; printf '%s\n' "$*" >&2; _c 0; }
+warn() { _c 33; printf '%s\n' "$*" >&2; _c 0; }
+info() { _c 36; printf '%s\n' "$*" >&2; _c 0; }
+ok()   { _c 32; printf '%s\n' "$*" >&2; _c 0; }
+
+# ── resolve the REAL claude binary (none of our names is "claude", so safe) ───
+REAL_CLAUDE="$(command -v claude 2>/dev/null || true)"
+
+# ── load + parse Huawei config (sets KEY MODEL REGION BASE_URL) ───────────────
+load_huawei_config() {
+  [ -f "$KEYFILE" ] || { err "Huawei key file not found: $KEYFILE"; exit 1; }
+  KEY=""; local F_MODEL="" F_BASEURL="" F_REGION="" line k v
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"          # ltrim
+    line="${line%"${line##*[![:space:]]}"}"          # rtrim
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    case "$line" in
+      *=*)
+        k="$(printf '%s' "${line%%=*}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        v="${line#*=}"
+        v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"   # trim
+        v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"               # strip quotes
+        case "$k" in
+          key|api_key|apikey|token|auth_token) KEY="$v" ;;
+          model)                               F_MODEL="$v" ;;
+          base_url|baseurl|url)                F_BASEURL="$v" ;;
+          region)                              F_REGION="$v" ;;
+        esac
+        ;;
+      *) [ -z "$KEY" ] && KEY="$line" ;;                                 # bare key line
+    esac
+  done < "$KEYFILE"
+  [ -n "$KEY" ] || { err "No API key found in $KEYFILE"; exit 1; }
+
+  REGION="${CLAUDE_HUAWEI_REGION:-${F_REGION:-$DEFAULT_REGION}}"
+  MODEL="${CLAUDE_HUAWEI_MODEL:-${F_MODEL:-$DEFAULT_MODEL}}"
+  BASE_URL="${CLAUDE_HUAWEI_BASE_URL:-${F_BASEURL:-https://api-${REGION}.modelarts-maas.com/anthropic}}"
+}
+
+# ── preflight: one tiny Anthropic-style request to confirm model is reachable ─
+# Key travels via curl -K- (stdin), never on argv, so it can't leak through `ps`.
+preflight() {
+  [ "${CLAUDE_HUAWEI_NO_CHECK:-0}" = "1" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  local tmp code json
+  tmp="$(mktemp -t claude_huawei_pf.XXXXXX)"
+  json='{"model":"'"$MODEL"'","max_tokens":4,"messages":[{"role":"user","content":"ping"}]}'
+  code="$(curl -sS -m 25 -o "$tmp" -w '%{http_code}' \
+            -H 'anthropic-version: 2023-06-01' -H 'Content-Type: application/json' \
+            --data "$json" -K- "${BASE_URL}/v1/messages" <<EOF || true
+header = "Authorization: Bearer ${KEY}"
+EOF
+)"
+  local body; body="$(cat "$tmp" 2>/dev/null || true)"; rm -f "$tmp"
+  case "$code" in
+    200) ok "  ✓ reachable — model '${MODEL}' responded OK" ;;
+    403) err   "  ✗ model '${MODEL}' → HTTP 403 (your key is not entitled to it yet)."
+         warn  "    Fix: enable/subscribe '${MODEL}' in the Huawei MaaS console, or use a model"
+         warn  "         your key already has, e.g.:  CLAUDE_HUAWEI_MODEL=glm-5.1 ${PROG} ..."
+         warn  "    (glm-5.1, glm-5, deepseek-v3.2 are accessible today — 'claude-switch models')"
+         return 1 ;;
+    *)   warn  "  ⚠ preflight HTTP ${code} for '${MODEL}': ${body:0:200}" ;;
+  esac
+  return 0
+}
+
+# ── list models the key can see (catalog; access still depends on entitlement) ─
+list_models() {
+  load_huawei_config
+  command -v curl >/dev/null 2>&1 || { err "curl is required for 'models'"; exit 1; }
+  info "Models visible to your key in region ${REGION}:"
+  curl -sS -m 25 -K- "https://api-${REGION}.modelarts-maas.com/v1/models" <<EOF | \
+    python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception as e: print("  (could not parse response)"); sys.exit(0)
+for m in (d.get("data") or []):
+    print("  -", m.get("id") if isinstance(m,dict) else m)'
+header = "Authorization: Bearer ${KEY}"
+EOF
+}
+
+# ── run modes ────────────────────────────────────────────────────────────────
+need_real_claude() {
+  [ -n "$REAL_CLAUDE" ] || { err "claude CLI not found in PATH."; exit 127; }
+}
+
+# args that don't talk to the model API → skip the preflight probe
+skip_preflight_for() {
+  case "${1:-}" in
+    -v|--version|--help|-h|update|doctor|mcp|config|install) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_cloud() {
+  need_real_claude
+  unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY \
+        ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL \
+        ANTHROPIC_DEFAULT_HAIKU_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL \
+        CLAUDE_CODE_SUBAGENT_MODEL CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 2>/dev/null || true
+  info "→ Claude Cloud (Anthropic — your login/subscription)"
+  exec "$REAL_CLAUDE" "$@"
+}
+
+run_huawei() {
+  need_real_claude
+  load_huawei_config
+  info "→ Claude via Huawei MaaS   model=${MODEL}   endpoint=${BASE_URL}"
+  if ! skip_preflight_for "${1:-}"; then
+    if ! preflight; then
+      warn  "  Aborting. Re-run with a working model, or CLAUDE_HUAWEI_NO_CHECK=1 to launch anyway."
+      exit 1
+    fi
+  fi
+  export ANTHROPIC_BASE_URL="$BASE_URL"
+  export ANTHROPIC_AUTH_TOKEN="$KEY"
+  unset  ANTHROPIC_API_KEY 2>/dev/null || true
+  # Map every model "slot" to the GLM model so background/haiku/sonnet/opus
+  # routing never tries to reach a real claude-* id that MaaS doesn't host.
+  export ANTHROPIC_MODEL="$MODEL"
+  export ANTHROPIC_SMALL_FAST_MODEL="$MODEL"
+  export ANTHROPIC_DEFAULT_HAIKU_MODEL="$MODEL"
+  export ANTHROPIC_DEFAULT_SONNET_MODEL="$MODEL"
+  export ANTHROPIC_DEFAULT_OPUS_MODEL="$MODEL"
+  export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
+  export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+  exec "$REAL_CLAUDE" "$@"
+}
+
+usage() {
+  cat >&2 <<USAGE
+claude-switch — toggle Claude Code between Anthropic Cloud and Huawei MaaS (GLM)
+
+  claude-cloud  [args...]      Anthropic Claude (your login/subscription)
+  claude-huawei [args...]      Huawei MaaS GLM (default model: ${DEFAULT_MODEL})
+
+  claude-switch cloud  [args]  same as claude-cloud
+  claude-switch huawei [args]  same as claude-huawei
+  claude-switch check          probe Huawei endpoint+model (no Claude launch)
+  claude-switch models         list models your Huawei key can see
+  claude-switch help           this help
+
+  Huawei key file : ${KEYFILE}
+  One-off model   : CLAUDE_HUAWEI_MODEL=glm-5.1 claude-huawei
+USAGE
+}
+
+# ── dispatch ─────────────────────────────────────────────────────────────────
+mode=""
+case "$PROG" in
+  claude-cloud)  mode=cloud ;;
+  claude-huawei) mode=huawei ;;
+esac
+
+if [ -z "$mode" ]; then
+  sub="${1:-}"; [ $# -gt 0 ] && shift || true
+  case "$sub" in
+    cloud)            mode=cloud ;;
+    huawei|glm|maas)  mode=huawei ;;
+    check)            load_huawei_config; info "endpoint=${BASE_URL}  model=${MODEL}"; preflight; exit $? ;;
+    models)           list_models; exit 0 ;;
+    ""|help|-h|--help) usage; exit 0 ;;
+    *) err "Unknown subcommand: '$sub'"; usage; exit 2 ;;
+  esac
+fi
+
+case "$mode" in
+  cloud)  run_cloud  "$@" ;;
+  huawei) run_huawei "$@" ;;
+esac

--- a/scripts/claude-switch/huawei-maas.example
+++ b/scripts/claude-switch/huawei-maas.example
@@ -1,0 +1,16 @@
+# ~/.huawei-maas — credentials/config for `claude-huawei` (Huawei MaaS / GLM).
+#
+# Setup:
+#   cp scripts/claude-switch/huawei-maas.example ~/.huawei-maas
+#   chmod 600 ~/.huawei-maas
+#   # then replace the placeholder below with your real MaaS API key
+#
+# The FIRST non-comment line with no '=' is taken as your API key (the only
+# required value). Lines starting with '#' are ignored.
+PUT-YOUR-HUAWEI-MAAS-API-KEY-HERE
+#
+# Optional overrides (uncomment & edit). Matching CLAUDE_HUAWEI_* env vars win
+# over these file values at runtime.
+# model=glm-5.2
+# region=ap-southeast-1
+# base_url=https://api-ap-southeast-1.modelarts-maas.com/anthropic

--- a/scripts/claude-switch/links.txt
+++ b/scripts/claude-switch/links.txt
@@ -1,0 +1,4 @@
+# Symlinks created in the install bin dir (both names relative to that dir).
+# Format:  <link-name>  <target-name>
+claude-cloud   claude-switch
+claude-huawei  claude-switch


### PR DESCRIPTION
## What

- **New module `scripts/claude-switch/`** — toggle the Claude Code CLI between **Anthropic Cloud** (`claude-cloud`) and **Huawei MaaS GLM** (`claude-huawei`). Huawei MaaS exposes a native Anthropic-compatible endpoint, so no proxy/router is needed — just env vars pointing Claude Code at MaaS.
  - Per-process env isolation (no leak into your shell; cloud mode force-clears overrides)
  - Preflight reachability check that refuses to launch a broken session
  - One-place config in `~/.huawei-maas` with `CLAUDE_HUAWEI_*` env overrides
  - Secret stays in `~/.huawei-maas` (chmod 600) — **only a `huawei-maas.example` template is committed**
- **New `install.sh` + `Makefile`** — a generic installer that auto-discovers any `scripts/<module>/bin/` tool and installs it into a bin dir.
  - `--copy` (default) / `--link` (dev) / `--uninstall` / `--list` / `--bindir DIR`
  - Recreates declared symlinks from `links.txt` (e.g. `claude-cloud`, `claude-huawei` → `claude-switch`)
  - PATH check with guidance
- **README** — added the module to the Available Modules table and a new Installation section.

## Usage

```bash
./install.sh claude-switch            # install into ~/.local/bin
cp scripts/claude-switch/huawei-maas.example ~/.huawei-maas && chmod 600 ~/.huawei-maas
claude-huawei      # Claude Code on Huawei MaaS GLM
claude-cloud       # Claude Code on Anthropic
```

## Testing

- `bash -n` clean on `install.sh` and `claude-switch`
- Verified: `--list`, copy-install, symlink resolution, running via the installed name, `--link` dev mode, `--uninstall`, and the `make` wrappers
- Exec bits recorded as `100755`; no secret committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCuHToda4GrTxwJoMcNCsJ